### PR TITLE
feat(app): remove EVM only supports Evmos chain identifiers (9000 or 9001)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (recovery) [#25](https://github.com/luchenqun/ethos/pull/25) Remove recovery module.
 - (incentives) [#26](https://github.com/luchenqun/ethos/pull/26) Remove incentives module.
 - (claims) [#28](https://github.com/luchenqun/ethos/pull/28) Remove claims module and migrate the `EVMChannels` param to the `x/evm` module params.
-- (app) [#29](https://github.com/luchenqun/ethos/pull/29) Remove EVM only supports Evmos chain identifiers (9000 or 9001).
+- (app) [#29](https://github.com/luchenqun/ethos/pull/29) Change account prefix to ethos and base denom to aethos.
+- (app) [#30](https://github.com/luchenqun/ethos/pull/30) Remove EVM only supports Evmos chain identifiers (9000 or 9001).
 
 ### API Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (recovery) [#25](https://github.com/luchenqun/ethos/pull/25) Remove recovery module.
 - (incentives) [#26](https://github.com/luchenqun/ethos/pull/26) Remove incentives module.
 - (claims) [#28](https://github.com/luchenqun/ethos/pull/28) Remove claims module and migrate the `EVMChannels` param to the `x/evm` module params.
+- (app) [#29](https://github.com/luchenqun/ethos/pull/29) Remove EVM only supports Evmos chain identifiers (9000 or 9001).
 
 ### API Breaking
 

--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -126,10 +126,6 @@ func (k *Keeper) WithChainID(ctx sdk.Context) {
 		panic("chain id already set")
 	}
 
-	if !(chainID.Cmp(big.NewInt(9001)) == 0 || chainID.Cmp(big.NewInt(9000)) == 0) {
-		panic("EVM only supports Evmos chain identifiers (9000 or 9001)")
-	}
-
 	k.eip155ChainID = chainID
 }
 

--- a/x/evm/types/access_list_tx.go
+++ b/x/evm/types/access_list_tx.go
@@ -237,13 +237,6 @@ func (tx AccessListTx) Validate() error {
 		)
 	}
 
-	if !(chainID.Cmp(big.NewInt(9001)) == 0 || chainID.Cmp(big.NewInt(9000)) == 0) {
-		return errorsmod.Wrapf(
-			errortypes.ErrInvalidChainID,
-			"chain ID must be 9000 or 9001 on Evmos, got %s", chainID,
-		)
-	}
-
 	return nil
 }
 

--- a/x/evm/types/dynamic_fee_tx.go
+++ b/x/evm/types/dynamic_fee_tx.go
@@ -269,13 +269,6 @@ func (tx DynamicFeeTx) Validate() error {
 		)
 	}
 
-	if !(chainID.Cmp(big.NewInt(9001)) == 0 || chainID.Cmp(big.NewInt(9000)) == 0) {
-		return errorsmod.Wrapf(
-			errortypes.ErrInvalidChainID,
-			"chain ID must be 9000 or 9001 on Evmos, got %s", chainID,
-		)
-	}
-
 	return nil
 }
 

--- a/x/evm/types/legacy_tx.go
+++ b/x/evm/types/legacy_tx.go
@@ -214,13 +214,6 @@ func (tx LegacyTx) Validate() error {
 		)
 	}
 
-	if !(chainID.Cmp(big.NewInt(9001)) == 0 || chainID.Cmp(big.NewInt(9000)) == 0) {
-		return errorsmod.Wrapf(
-			errortypes.ErrInvalidChainID,
-			"chain ID must be 9000 or 9001 on Evmos, got %s", chainID,
-		)
-	}
-
 	return nil
 }
 

--- a/x/evm/types/msg_test.go
+++ b/x/evm/types/msg_test.go
@@ -430,19 +430,6 @@ func (suite *MsgsTestSuite) TestMsgEthereumTx_ValidateBasic() {
 			expectPass: false,
 			errMsg:     "failed to unpack tx data",
 		},
-		{
-			msg:        "invalid chain ID (neither 9000 nor 9001)",
-			to:         suite.to.Hex(),
-			amount:     hundredInt,
-			gasLimit:   1000,
-			gasPrice:   zeroInt,
-			gasFeeCap:  nil,
-			gasTipCap:  nil,
-			accessList: &ethtypes.AccessList{},
-			chainID:    hundredInt,
-			expectPass: false,
-			errMsg:     "chain ID must be 9000 or 9001 on Evmos",
-		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
## Description

 remove EVM only supports Evmos chain identifiers (9000 or 9001),  supports any chain id