### PR TITLE
imp(precompile-staking): implement the CreateValidator tx for staking precompiled contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (app) [#32](https://github.com/luchenqun/ethos/pull/32) Remove EVM only supports Evmos chain identifiers (9000 or 9001).
 - (app) [#33](https://github.com/luchenqun/ethos/pull/33) Rename evmosd to ethosd.
 - (precompile-staking) [#35](https://github.com/luchenqun/ethos/pull/35) Implement staking precompile contract.
+- (precompile-staking) [#37](https://github.com/luchenqun/ethos/pull/37) Implement the CreateValidator tx for staking precompiled contract.
 
 ### API Breaking
 

--- a/solidity/contracts/common/Types.sol
+++ b/solidity/contracts/common/Types.sol
@@ -6,3 +6,17 @@ struct Coin {
     string denom;
     uint256 amount;
 }
+
+struct Description {
+    string moniker;
+    string identity;
+    string website;
+    string securityContact;
+    string details;
+}
+
+struct CommissionRates {
+    uint256 rate;
+    uint256 maxRate;
+    uint256 maxChangeRate;
+}

--- a/solidity/contracts/staking/Decode.sol
+++ b/solidity/contracts/staking/Decode.sol
@@ -5,6 +5,13 @@ pragma solidity ^0.8.0;
 import "../common/Types.sol" as types;
 
 library Decode {
+    function createValidator(
+        bytes memory data
+    ) internal pure returns (bool) {
+        (bool success) = abi.decode(data, (bool));
+        return success;
+    }
+
     function delegate(
         bytes memory data
     ) internal pure returns (bool) {

--- a/solidity/contracts/staking/Encode.sol
+++ b/solidity/contracts/staking/Encode.sol
@@ -2,7 +2,26 @@
 
 pragma solidity ^0.8.0;
 
+import "../common/Types.sol";
+
 library Encode {
+    function createValidator(
+        Description calldata description,
+        CommissionRates calldata commission,
+        uint256 minSelfDelegation,
+        string memory pubkey,
+        uint256 value
+    ) internal pure returns (bytes memory) {
+        return abi.encodeWithSignature(
+            "createValidator(Description,CommissionRates,uint256,uint256)",
+            description,
+            commission,
+            minSelfDelegation,
+            pubkey,
+            value
+        );
+    }
+
     function delegate(
         address validatorAddress,
         uint256 amount

--- a/solidity/contracts/staking/IStaking.sol
+++ b/solidity/contracts/staking/IStaking.sol
@@ -5,6 +5,15 @@ pragma solidity ^0.8.0;
 import "../common/Types.sol";
 
 interface IStaking {
+
+    function createValidator(
+        Description calldata description,
+        CommissionRates calldata commission,
+        uint256 minSelfDelegation,
+        string memory pubkey,
+        uint256 value
+    ) external returns (bool success);
+
     function delegate(
         address validatorAddress,
         uint256 amount
@@ -31,6 +40,11 @@ interface IStaking {
         address delegatorAddress,
         address validatorAddress
     ) external view returns (uint256 shares, Coin memory balance);
+
+    event CreateValidator(
+        address indexed validator,
+        uint256 value
+    );
 
     event Delegate(
         address indexed delegator,

--- a/solidity/contracts/staking/StakingCall.sol
+++ b/solidity/contracts/staking/StakingCall.sol
@@ -11,6 +11,26 @@ import "./Decode.sol";
 library StakingCall {
     address public constant STAKING_ADDRESS = address(0x0000000000000000000000000000000000001003);
 
+    function createValidator(
+        Description calldata description,
+        CommissionRates calldata commission,
+        uint256 minSelfDelegation,
+        string memory pubkey,
+        uint256 value
+    ) internal returns (bool) {
+        (bool result, bytes memory data) = STAKING_ADDRESS.call(
+            Encode.createValidator(
+                description,
+                commission,
+                minSelfDelegation,
+                pubkey,
+                value
+            )
+        );
+        Decode.ok(result, data, "createValidator failed");
+        return Decode.createValidator(data);
+    }
+
     function delegate(
         address validatorAddress,
         uint256 amount

--- a/solidity/contracts/test/StakingTest.sol
+++ b/solidity/contracts/test/StakingTest.sol
@@ -11,6 +11,23 @@ import "../staking/StakingCall.sol";
 contract StakingTest is IStaking {
     mapping(string => uint256) public validatorShares;
 
+    function createValidator(
+        Description calldata description,
+        CommissionRates calldata commissionRates,
+        uint256 minSelfDelegation,
+        string memory pubkey,
+        uint256 value
+    ) external override returns (bool) {
+        bool success = StakingCall.createValidator(
+            description,
+            commissionRates,
+            minSelfDelegation,
+            pubkey,
+            value
+        );
+        return success;
+    }
+
     function delegate(
         address validatorAddress,
         uint256 amount

--- a/x/evm/precompiles/staking/IStaking.go
+++ b/x/evm/precompiles/staking/IStaking.go
@@ -35,9 +35,25 @@ type Coin struct {
 	Amount *big.Int
 }
 
+// CommissionRates is an auto generated low-level Go binding around an user-defined struct.
+type CommissionRates struct {
+	Rate          *big.Int
+	MaxRate       *big.Int
+	MaxChangeRate *big.Int
+}
+
+// Description is an auto generated low-level Go binding around an user-defined struct.
+type Description struct {
+	Moniker         string
+	Identity        string
+	Website         string
+	SecurityContact string
+	Details         string
+}
+
 // IStakingMetaData contains all meta data concerning the IStaking contract.
 var IStakingMetaData = &bind.MetaData{
-	ABI: "[{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"delegatorAddress\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"validatorAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"creationHeight\",\"type\":\"uint256\"}],\"name\":\"CancelUnbondingDelegation\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"delegator\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"Delegate\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"delegatorAddress\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"validatorSrcAddress\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"validatorDstAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"completionTime\",\"type\":\"uint256\"}],\"name\":\"Redelegate\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"delegatorAddress\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"validatorAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"completionTime\",\"type\":\"uint256\"}],\"name\":\"Undelegate\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validatorAddress\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"creationHeight\",\"type\":\"uint256\"}],\"name\":\"cancelUnbondingDelegation\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"success\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validatorAddress\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"delegate\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"success\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"delegatorAddress\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"validatorAddress\",\"type\":\"address\"}],\"name\":\"delegation\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"shares\",\"type\":\"uint256\"},{\"components\":[{\"internalType\":\"string\",\"name\":\"denom\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"internalType\":\"structCoin\",\"name\":\"balance\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validatorSrcAddress\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"validatorDstAddress\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"redelegate\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"completionTime\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validatorAddress\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"undelegate\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"completionTime\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
+	ABI: "[{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"delegatorAddress\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"validatorAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"creationHeight\",\"type\":\"uint256\"}],\"name\":\"CancelUnbondingDelegation\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"CreateValidator\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"delegator\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"Delegate\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"delegatorAddress\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"validatorSrcAddress\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"validatorDstAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"completionTime\",\"type\":\"uint256\"}],\"name\":\"Redelegate\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"delegatorAddress\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"validatorAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"completionTime\",\"type\":\"uint256\"}],\"name\":\"Undelegate\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validatorAddress\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"creationHeight\",\"type\":\"uint256\"}],\"name\":\"cancelUnbondingDelegation\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"success\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"string\",\"name\":\"moniker\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"identity\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"website\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"securityContact\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"details\",\"type\":\"string\"}],\"internalType\":\"structDescription\",\"name\":\"description\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"rate\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxRate\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxChangeRate\",\"type\":\"uint256\"}],\"internalType\":\"structCommissionRates\",\"name\":\"commission\",\"type\":\"tuple\"},{\"internalType\":\"uint256\",\"name\":\"minSelfDelegation\",\"type\":\"uint256\"},{\"internalType\":\"string\",\"name\":\"pubkey\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"createValidator\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"success\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validatorAddress\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"delegate\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"success\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"delegatorAddress\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"validatorAddress\",\"type\":\"address\"}],\"name\":\"delegation\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"shares\",\"type\":\"uint256\"},{\"components\":[{\"internalType\":\"string\",\"name\":\"denom\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"internalType\":\"structCoin\",\"name\":\"balance\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validatorSrcAddress\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"validatorDstAddress\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"redelegate\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"completionTime\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validatorAddress\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"undelegate\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"completionTime\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
 }
 
 // IStakingABI is the input ABI used to generate the binding from.
@@ -252,6 +268,27 @@ func (_IStaking *IStakingTransactorSession) CancelUnbondingDelegation(validatorA
 	return _IStaking.Contract.CancelUnbondingDelegation(&_IStaking.TransactOpts, validatorAddress, amount, creationHeight)
 }
 
+// CreateValidator is a paid mutator transaction binding the contract method 0x3adeba1e.
+//
+// Solidity: function createValidator((string,string,string,string,string) description, (uint256,uint256,uint256) commission, uint256 minSelfDelegation, string pubkey, uint256 value) returns(bool success)
+func (_IStaking *IStakingTransactor) CreateValidator(opts *bind.TransactOpts, description Description, commission CommissionRates, minSelfDelegation *big.Int, pubkey string, value *big.Int) (*types.Transaction, error) {
+	return _IStaking.contract.Transact(opts, "createValidator", description, commission, minSelfDelegation, pubkey, value)
+}
+
+// CreateValidator is a paid mutator transaction binding the contract method 0x3adeba1e.
+//
+// Solidity: function createValidator((string,string,string,string,string) description, (uint256,uint256,uint256) commission, uint256 minSelfDelegation, string pubkey, uint256 value) returns(bool success)
+func (_IStaking *IStakingSession) CreateValidator(description Description, commission CommissionRates, minSelfDelegation *big.Int, pubkey string, value *big.Int) (*types.Transaction, error) {
+	return _IStaking.Contract.CreateValidator(&_IStaking.TransactOpts, description, commission, minSelfDelegation, pubkey, value)
+}
+
+// CreateValidator is a paid mutator transaction binding the contract method 0x3adeba1e.
+//
+// Solidity: function createValidator((string,string,string,string,string) description, (uint256,uint256,uint256) commission, uint256 minSelfDelegation, string pubkey, uint256 value) returns(bool success)
+func (_IStaking *IStakingTransactorSession) CreateValidator(description Description, commission CommissionRates, minSelfDelegation *big.Int, pubkey string, value *big.Int) (*types.Transaction, error) {
+	return _IStaking.Contract.CreateValidator(&_IStaking.TransactOpts, description, commission, minSelfDelegation, pubkey, value)
+}
+
 // Delegate is a paid mutator transaction binding the contract method 0x026e402b.
 //
 // Solidity: function delegate(address validatorAddress, uint256 amount) returns(bool success)
@@ -464,6 +501,151 @@ func (_IStaking *IStakingFilterer) WatchCancelUnbondingDelegation(opts *bind.Wat
 func (_IStaking *IStakingFilterer) ParseCancelUnbondingDelegation(log types.Log) (*IStakingCancelUnbondingDelegation, error) {
 	event := new(IStakingCancelUnbondingDelegation)
 	if err := _IStaking.contract.UnpackLog(event, "CancelUnbondingDelegation", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// IStakingCreateValidatorIterator is returned from FilterCreateValidator and is used to iterate over the raw logs and unpacked data for CreateValidator events raised by the IStaking contract.
+type IStakingCreateValidatorIterator struct {
+	Event *IStakingCreateValidator // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *IStakingCreateValidatorIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(IStakingCreateValidator)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(IStakingCreateValidator)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *IStakingCreateValidatorIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *IStakingCreateValidatorIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// IStakingCreateValidator represents a CreateValidator event raised by the IStaking contract.
+type IStakingCreateValidator struct {
+	Validator common.Address
+	Value     *big.Int
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterCreateValidator is a free log retrieval operation binding the contract event 0x9bdb560f8135cb46033a55410c14e14b1a7bc2d3f3e9973f4b49533e176468b0.
+//
+// Solidity: event CreateValidator(address indexed validator, uint256 value)
+func (_IStaking *IStakingFilterer) FilterCreateValidator(opts *bind.FilterOpts, validator []common.Address) (*IStakingCreateValidatorIterator, error) {
+
+	var validatorRule []interface{}
+	for _, validatorItem := range validator {
+		validatorRule = append(validatorRule, validatorItem)
+	}
+
+	logs, sub, err := _IStaking.contract.FilterLogs(opts, "CreateValidator", validatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return &IStakingCreateValidatorIterator{contract: _IStaking.contract, event: "CreateValidator", logs: logs, sub: sub}, nil
+}
+
+// WatchCreateValidator is a free log subscription operation binding the contract event 0x9bdb560f8135cb46033a55410c14e14b1a7bc2d3f3e9973f4b49533e176468b0.
+//
+// Solidity: event CreateValidator(address indexed validator, uint256 value)
+func (_IStaking *IStakingFilterer) WatchCreateValidator(opts *bind.WatchOpts, sink chan<- *IStakingCreateValidator, validator []common.Address) (event.Subscription, error) {
+
+	var validatorRule []interface{}
+	for _, validatorItem := range validator {
+		validatorRule = append(validatorRule, validatorItem)
+	}
+
+	logs, sub, err := _IStaking.contract.WatchLogs(opts, "CreateValidator", validatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(IStakingCreateValidator)
+				if err := _IStaking.contract.UnpackLog(event, "CreateValidator", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseCreateValidator is a log parse operation binding the contract event 0x9bdb560f8135cb46033a55410c14e14b1a7bc2d3f3e9973f4b49533e176468b0.
+//
+// Solidity: event CreateValidator(address indexed validator, uint256 value)
+func (_IStaking *IStakingFilterer) ParseCreateValidator(log types.Log) (*IStakingCreateValidator, error) {
+	event := new(IStakingCreateValidator)
+	if err := _IStaking.contract.UnpackLog(event, "CreateValidator", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log

--- a/x/evm/precompiles/staking/contract.go
+++ b/x/evm/precompiles/staking/contract.go
@@ -39,6 +39,8 @@ func (c *Contract) RequiredGas(input []byte) uint64 {
 	}
 
 	switch method.Name {
+	case CreateValidatorMethodName:
+		return CreateValidatorGas
 	case DelegateMethodName:
 		return DelegateGas
 	case UndelegateMethodName:
@@ -66,6 +68,8 @@ func (c *Contract) Run(evm *vm.EVM, contract *vm.Contract, readonly bool) (ret [
 	if err == nil {
 		// parse input
 		switch method.Name {
+		case CreateValidatorMethodName:
+			ret, err = c.CreateValidator(cacheCtx, evm, contract, readonly)
 		case DelegateMethodName:
 			ret, err = c.Delegate(cacheCtx, evm, contract, readonly)
 		case UndelegateMethodName:


### PR DESCRIPTION
## Description

use precompiled contract creating a new validator

## Steps

### Step 1

Use the command `ethosd tendermint show-validator --home=./nodes/node1/ethosd` to obtain the node public key for node1. Let's assume the obtained content is as follows:

```json
{
    "@type":"/cosmos.crypto.ed25519.PubKey",
    "key":"YbrWrxBJc0Xa/CiaknBLVscydAO2QXj93mwVrETlcCM="
}
```

The **key** is the node1 public key.

### Step 2

Call the `createValidator` method in the Staking precompiled contract with the following parameters:

- `description`: ["node1","I'm identity","[http://cosmos.lucq.fun](http://cosmos.lucq.fun/)","0x1003","I'm details"]
- `commissionRates`: ["100000000000000000","100000000000000000","100000000000000000"]
- `minSelfDelegation`: 1
- `pubkey`: YbrWrxBJc0Xa/CiaknBLVscydAO2QXj93mwVrETlcCM=
- `value`: 100000000000000000000

Note that the input parameters in the `commissionRates` field should be decimal numbers with a precision of 18. So, the decimal values shown above are all 0.1. Replace `pubkey` with your actual values. 